### PR TITLE
update for blender 3.2

### DIFF
--- a/gltf_multiexport.py
+++ b/gltf_multiexport.py
@@ -71,7 +71,7 @@ bpy.types.Object.gltf_export_format = bpy.props.EnumProperty(
 
 bpy.types.Object.gltf_export_image_format = bpy.props.EnumProperty(
     name='Images',
-    items=(('NAME', 'Automatic',
+    items=(('AUTO', 'Automatic',
             'Determine the image format from the blender image name'),
             ('JPEG', 'JPEG Format (.jpg)',
             'Encode and save textures as .jpg files. Be aware of a possible loss in quality'),
@@ -82,7 +82,7 @@ bpy.types.Object.gltf_export_image_format = bpy.props.EnumProperty(
         'Output format for images. PNG is lossless and generally preferred, but JPEG might be preferable for web '
         'applications due to the smaller file size'
     ),
-    default='NAME',
+    default='AUTO',
     options= set()
 )
 
@@ -166,10 +166,17 @@ bpy.types.Object.gltf_export_tangents = bpy.props.BoolProperty(
     options= set()
 )
 
-bpy.types.Object.gltf_export_materials = bpy.props.BoolProperty(
+bpy.types.Object.gltf_export_materials = bpy.props.EnumProperty(
     name='Materials',
+    items=(('EXPORT', 'Export',
+            'Export all materials used by included objects.'),
+           ('PLACEHOLDER', 'Placeholder',
+            'Do not export materials, but write multiple primitive groups per mesh, keeping material slot information.. '
+            ),
+           ('GLTF_SEPARATE', 'No export)',
+            'Do not export materials, and combine mesh primitive groups, losing material slot information.')),
     description='Export materials',
-    default=True,
+    default='EXPORT',
     options= set()
 )
 
@@ -536,7 +543,7 @@ def exportSelection(context, obj, path):
     bpy.ops.export_scene.gltf(
         export_format = obj.gltf_export_format,
         export_copyright = copyright,
-        export_selected = True,
+        use_selection = True,
         filepath= path,
 
         export_image_format = obj.gltf_export_image_format,
@@ -762,4 +769,3 @@ def unregister():
 
 if __name__ == "__main__":
     register()
-


### PR DESCRIPTION
the image format changed from NAME to AUTO for automatic selection, gltf changed from a bool to enum to support [export, placeholder, gltf_separate], and the variable for deciding to use selected or not changed from export_selected to use_selection

I'm not sure if there is any intent to maintain this repository anymore but given that this tool is one of the first to come up in searches I thought I would try this pull request. The changes here are all that is required for Blender 3.2 compatibility and was tested with the default settings. Either making these changes yourself or using my fork should get most people going again.

These changes are dedicated to the public domain and under a MIT license where public domain dedications are not available.